### PR TITLE
fix: make packages registry secret optional

### DIFF
--- a/chart/templates/secrets/imagepullsecret.yaml
+++ b/chart/templates/secrets/imagepullsecret.yaml
@@ -1,5 +1,6 @@
 {{- /* Used for pulling images from custom registries.  One per namespace */ -}}
-{{- if .Values.registryCredentials -}}
+{{- /* registryCredentials are required via schema; generate secrets if required dockerconfigjson inputs are present */ -}}
+{{- if and .Values.registryCredentials.registry .Values.registryCredentials.username .Values.registryCredentials.password -}}
 {{- range $ns := compact (splitList " " (include "uniqueNamespaces" (merge (dict "default" true) .))) -}}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
## Description
Fixes logic for generating registry credential secrets for `packages`. Since `registryCredentials` are required via schema, updates logic to depend on required dockerconfigjson properties.

## Tests
### Negative Test Case

Using default values from chart along with the following packages-values:
```yaml
packages:
  podinfo:
    git:
      repo: https://github.com/stefanprodan/podinfo.git
      tag: 6.3.4
      path: charts/podinfo
    flux:
      timeout: 5m
    postRenderers: []
    dependsOn:
      - name: monitoring
        namespace: bigbang
    values:
      replicaCount: 3
  somepackage:
    git:
      repo: https://github.com/stefanprodan/podinfo.git
      tag: 6.3.4
      path: charts/podinfo
    flux:
      timeout: 5m
    postRenderers: []
    dependsOn:
      - name: monitoring
        namespace: bigbang
    values:
      replicaCount: 3
```

Chart successfully renders no `private-registry` secrets for either `packages`.

### Positive Test Case

Using default values from chart along with the following packages-values:
```yaml
packages:
  podinfo:
    git:
      repo: https://github.com/stefanprodan/podinfo.git
      tag: 6.3.4
      path: charts/podinfo
    flux:
      timeout: 5m
    postRenderers: []
    dependsOn:
      - name: monitoring
        namespace: bigbang
    values:
      replicaCount: 3
  somepackage:
    git:
      repo: https://github.com/stefanprodan/podinfo.git
      tag: 6.3.4
      path: charts/podinfo
    flux:
      timeout: 5m
    postRenderers: []
    dependsOn:
      - name: monitoring
        namespace: bigbang
    values:
      replicaCount: 3

registryCredentials:
  registry: someregistry
  username: someusername
  password: somepassword
```

Successfully generates the following secrets:
```yaml
---
# Source: bigbang/templates/secrets/imagepullsecret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: private-registry
  namespace: podinfo
  labels:
    app.kubernetes.io/name: private-registry
    app.kubernetes.io/instance: bb
    app.kubernetes.io/version: 2.10.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: "bigbang"
    helm.sh/chart: bigbang-2.10.0
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: eyJhdXRocyI6eyJzb21lcmVnaXN0cnkiOnsidXNlcm5hbWUiOiJzb21ldXNlcm5hbWUiLCJwYXNzd29yZCI6InNvbWVwYXNzd29yZCIsImVtYWlsIjoiIiwiYXV0aCI6ImMyOXRaWFZ6WlhKdVlXMWxPbk52YldWd1lYTnpkMjl5WkE9PSJ9fX0=
---
# Source: bigbang/templates/secrets/imagepullsecret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: private-registry
  namespace: somepackage
  labels:
    app.kubernetes.io/name: private-registry
    app.kubernetes.io/instance: bb
    app.kubernetes.io/version: 2.10.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: "bigbang"
    helm.sh/chart: bigbang-2.10.0
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: eyJhdXRocyI6eyJzb21lcmVnaXN0cnkiOnsidXNlcm5hbWUiOiJzb21ldXNlcm5hbWUiLCJwYXNzd29yZCI6InNvbWVwYXNzd29yZCIsImVtYWlsIjoiIiwiYXV0aCI6ImMyOXRaWFZ6WlhKdVlXMWxPbk52YldWd1lYTnpkMjl5WkE9PSJ9fX0=
```

## For Issue
Closes [#1710](https://repo1.dso.mil/big-bang/bigbang/-/issues/17100)