### PR TITLE
feat(gitlab): allow setting object store endpoint for iam profile

### DIFF
--- a/chart/templates/gitlab/secret-objectstore.yaml
+++ b/chart/templates/gitlab/secret-objectstore.yaml
@@ -16,6 +16,8 @@ stringData:
       {{- else if eq .Values.addons.gitlab.objectStorage.iamProfile "" }}
       aws_access_key_id: {{ .Values.addons.gitlab.objectStorage.accessKey }}
       aws_secret_access_key: {{ .Values.addons.gitlab.objectStorage.accessSecret }}
+      {{- end }}
+      {{- if .Values.addons.gitlab.objectStorage.endpoint }}
       endpoint: "{{ .Values.addons.gitlab.objectStorage.endpoint }}"
       {{- end }}
       {{- if eq .Values.addons.gitlab.objectStorage.type "minio" }}
@@ -36,6 +38,8 @@ stringData:
         {{- if eq .Values.addons.gitlab.objectStorage.iamProfile "" }}
         accesskey: {{ .Values.addons.gitlab.objectStorage.accessKey }}
         secretkey: {{ .Values.addons.gitlab.objectStorage.accessSecret }}
+        {{- end }}
+        {{- if .Values.addons.gitlab.objectStorage.endpoint }}
         regionendpoint: "{{ .Values.addons.gitlab.objectStorage.endpoint }}"
         {{- end }}
         region: {{ .Values.addons.gitlab.objectStorage.region }}


### PR DESCRIPTION
## Description

Allows setting Gitlab object store endpoint when using IAM profile

## Testing

### Negative Test IAM Profile (not setting endpoint)

custom-values.yaml:

```yaml
addons:
  gitlab:
    enabled: true
    objectStorage:
      type: "s3"
      region: "us-gov-west-1"
      bucketPrefix: "my-prefix"
      iamProfile: "my-profile"
```

Command: `helm template . -f custom-values.yaml -s templates/gitlab/secret-objectstore.yaml`

Output:

```yaml
---
# Source: bigbang/templates/gitlab/secret-objectstore.yaml
apiVersion: v1
kind: Secret
metadata:
    name: gitlab-object-storage
    namespace: gitlab
type: kubernetes.io/opaque
stringData:
    rails: |-
      provider: AWS
      region: us-gov-west-1
      use_iam_profile: true
    registry: |-
      s3:
        bucket: my-prefix-gitlab-registry
        region: us-gov-west-1
        v4auth: true
    backups: |-
      [default]
      bucket_location = us-gov-west-1
      multipart_chunk_size_mb = 128
```

### Negative Test AccessKey/AccessSecret (not setting endpoint)

custom-values.yaml:

```yaml
addons:
  gitlab:
    enabled: true
    objectStorage:
      type: "s3"
      region: "us-gov-west-1"
      bucketPrefix: "my-prefix"
      accessKey: "my-key"
      accessSecret: "my-secret"
```

Command: `helm template . -f custom-values.yaml -s templates/gitlab/secret-objectstore.yaml`

Output:

```yaml
---
# Source: bigbang/templates/gitlab/secret-objectstore.yaml
apiVersion: v1
kind: Secret
metadata:
    name: gitlab-object-storage
    namespace: gitlab
type: kubernetes.io/opaque
stringData:
    rails: |-
      provider: AWS
      region: us-gov-west-1
      aws_access_key_id: my-key
      aws_secret_access_key: my-secret
    registry: |-
      s3:
        bucket: my-prefix-gitlab-registry
        accesskey: my-key
        secretkey: my-secret
        region: us-gov-west-1
        v4auth: true
    backups: |-
      [default] 
      access_key = my-key
      secret_key = my-secret
      host_bucket = %(bucket)s.
      bucket_location = us-gov-west-1
      multipart_chunk_size_mb = 128
```

### Positive Test IAM Profile (setting endpoint)

custom-values.yaml:

```yaml
addons:
  gitlab:
    enabled: true
    objectStorage:
      type: "s3"
      region: "us-gov-west-1"
      bucketPrefix: "my-prefix"
      iamProfile: "my-profile"
      endpoint: "https://s3.us-gov-west-1.amazonaws.com"
```

Command: `helm template . -f custom-values.yaml -s templates/gitlab/secret-objectstore.yaml`

Output:

```yaml
---
# Source: bigbang/templates/gitlab/secret-objectstore.yaml
apiVersion: v1
kind: Secret
metadata:
    name: gitlab-object-storage
    namespace: gitlab
type: kubernetes.io/opaque
stringData:
    rails: |-
      provider: AWS
      region: us-gov-west-1
      use_iam_profile: true
      endpoint: "https://s3.us-gov-west-1.amazonaws.com"
    registry: |-
      s3:
        bucket: my-prefix-gitlab-registry
        regionendpoint: "https://s3.us-gov-west-1.amazonaws.com"
        region: us-gov-west-1
        v4auth: true
    backups: |-
      [default]
      bucket_location = us-gov-west-1
      multipart_chunk_size_mb = 128
```

### Positive Test AccessKey/AccessSecret (setting endpoint)

custom-values.yaml:

```yaml
addons:
  gitlab:
    enabled: true
    objectStorage:
      type: "s3"
      region: "us-gov-west-1"
      bucketPrefix: "my-prefix"
      accessKey: "my-key"
      accessSecret: "my-secret"
      endpoint: "https://s3.us-gov-west-1.amazonaws.com"
```

Command: `helm template . -f custom-values.yaml -s templates/gitlab/secret-objectstore.yaml`

Output:

```yaml
---
# Source: bigbang/templates/gitlab/secret-objectstore.yaml
apiVersion: v1
kind: Secret
metadata:
    name: gitlab-object-storage
    namespace: gitlab
type: kubernetes.io/opaque
stringData:
    rails: |-
      provider: AWS
      region: us-gov-west-1
      aws_access_key_id: my-key
      aws_secret_access_key: my-secret
      endpoint: "https://s3.us-gov-west-1.amazonaws.com"
    registry: |-
      s3:
        bucket: my-prefix-gitlab-registry
        accesskey: my-key
        secretkey: my-secret
        regionendpoint: "https://s3.us-gov-west-1.amazonaws.com"
        region: us-gov-west-1
        v4auth: true
    backups: |-
      [default] 
      access_key = my-key
      secret_key = my-secret
      host_bucket = %(bucket)s.s3.us-gov-west-1.amazonaws.com
      bucket_location = us-gov-west-1
      multipart_chunk_size_mb = 128
```
