### PR TITLE
bugfix - grafana values template has a misplaced end tag

### DIFF
--- a/chart/templates/grafana/values.yaml
+++ b/chart/templates/grafana/values.yaml
@@ -305,7 +305,6 @@ extraSecretMounts:
 {{- if .Values.monitoring.enabled }}
 serviceMonitor:
   enabled: true
-{{- end }}
 {{- if $istioInjection }}
   scheme: https
   tlsConfig:
@@ -313,6 +312,7 @@ serviceMonitor:
     certFile: /etc/prom-certs/cert-chain.pem
     keyFile: /etc/prom-certs/key.pem
     insecureSkipVerify: true  # Prometheus does not support Istio security naming, thus skip verifying target pod certificate
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
The `{{- end }}` tag's current placement means that if `monitoring: false` and `istio: true`, then a block containing istio data meant to be used by monitoring will still be rendered. However, the accompanying `monitoring` block within which the istio data should be enclosed is not rendered (please see examples below).  

This, at its most benign, leads superfluous data being added to the `grafana.ini` block. At its most disruptive, like when `grafana.sso.enabled: true` and `grafana.sso.grafana.clientid` is set, the issue leads to malformed yaml that can't be converted to json and therefore cannot be deployed to the cluster.

Moving the `{{- end }}` fixes these issues.

I found that this issue has surfaced previously here: https://repo1.dso.mil/big-bang/bigbang/-/issues/2426

### **Pre-fix Examples:**
**Monitoring off, Istio on, SSO off**
_Note: `scheme:  https` and below renders as part of `grafana.ini` which it should not_ 
```
  grafana.ini:
    server:
      root_url: https://grafana.dev.bigbang.mil/

    auth.generic_oauth:
      enabled: false
      name: SSO                    
    scheme:      https
    tlsConfig:
      caFile: /etc/prom-certs/root-cert.pem
      certFile: /etc/prom-certs/cert-chain.pem
      keyFile: /etc/prom-certs/key.pem
      insecureSkipVerify: true
```

**Monitoring off, Istio on, SSO on, ClientId set**
_Note:  the `scheme` block now renders in such a way as to create malformed yaml_ 
```
grafana.ini:
    server:
      root_url: https://grafana.dev.bigbang.mil/

    auth.generic_oauth:
      enabled: true
      name: SSO
      client_id: $__file{/etc/secrets/auth_generic_oauth/client_id}
      client_secret: $__file{/etc/secrets/auth_generic_oauth/client_secret}
      scopes:      monkey_trial
      auth_url: https://login.dso.mil/auth/realms/baby-yoda/protocol/openid-connect/auth
      token_url: https://login.dso.mil/auth/realms/baby-yoda/protocol/openid-connect/token
      api_url: https://login.dso.mil/auth/realms/baby-yoda/protocol/openid-connect/userinfo
      allow_sign_up: true
      role_attribute_path: Viewer                    
  extraSecretMounts:
    - name: auth-generic-oauth-secret
      mountPath: /etc/secrets/auth_generic_oauth
      secretName: grafana-sso
      defaultMode: 0440    
      readOnly: true
    scheme:      https
    tlsConfig:
      caFile: /etc/prom-certs/root-cert.pem
      certFile: /etc/prom-certs/cert-chain.pem
      keyFile: /etc/prom-certs/key.pem
      insecureSkipVerify: true
```

### **Post-fix Examples:**
**Monitoring off, Istio on, SSO off**
_Note: the `monitoring` block simply does not render_
```
  grafana.ini:
    server:
      root_url: https://grafana.dev.bigbang.mil/

    auth.generic_oauth:
      enabled: false
      name: SSO
```

**Monitoring off, Istio on, SSO on, ClientId set**
_Note: same as above, the `monitoring` block does not render_
```
  grafana.ini:
    server:
      root_url: https://grafana.dev.bigbang.mil/

    auth.generic_oauth:
      enabled: true
      name: SSO
      client_id: $__file{/etc/secrets/auth_generic_oauth/client_id}
      client_secret: $__file{/etc/secrets/auth_generic_oauth/client_secret}
      scopes:      monkey_trial
      auth_url: https://login.dso.mil/auth/realms/baby-yoda/protocol/openid-connect/auth
      token_url: https://login.dso.mil/auth/realms/baby-yoda/protocol/openid-connect/token
      api_url: https://login.dso.mil/auth/realms/baby-yoda/protocol/openid-connect/userinfo
      allow_sign_up: true
      role_attribute_path: Viewer                    
  extraSecretMounts:
    - name: auth-generic-oauth-secret
      mountPath: /etc/secrets/auth_generic_oauth
      secretName: grafana-sso
      defaultMode: 0440    
      readOnly: true"
```